### PR TITLE
Add tab to align paper tape in strokes list

### DIFF
--- a/plover_cat/main_window.py
+++ b/plover_cat/main_window.py
@@ -1637,7 +1637,7 @@ class PloverCATWindow(QMainWindow, Ui_PloverCAT):
         if self.recorder.state() == QMediaRecorder.RecordingState:
             real_time = self.recorder.duration() - self.audioDelay.value()
             audio_time = ms_to_hours(real_time)
-        log_string = "{0}|{1}|({2},{3})|{4}".format(self.stroke_time, audio_time, self.cursor_block, self.cursor_block_position, steno)
+        log_string = "{0}|{1}|({2},{3})\t|{4}|".format(self.stroke_time, audio_time, self.cursor_block, self.cursor_block_position, steno)
         self.strokeList.appendPlainText(log_string)
         if not self.file_name:
             return

--- a/plover_cat/plover_cat.ui
+++ b/plover_cat/plover_cat.ui
@@ -463,6 +463,9 @@ position.</string>
        <property name="lineWrapMode">
         <enum>QPlainTextEdit::NoWrap</enum>
        </property>
+       <property name="tabStopDistance">
+        <double>50.000000000000000</double>
+       </property>
        <property name="readOnly">
         <bool>true</bool>
        </property>


### PR DESCRIPTION
I've mentioned attempts at making the paper tape easier to read before. The entire refactor would be really hard, but over a few weeks of testing this easier solution works really well and provides quite a lot of space for the coordinate numbers to grow. In most of my short to medium length transcription exercises it's proven to be sufficient, and it doesn't appear to have broken anything depending on the formatting of the stroke list.

There is an extra | character at the end of each line; this is merely to make it easier to determine that one is scrolled all the way to the right without having to mash -Z a bunch. 